### PR TITLE
Moved builtin funtions into separated files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,14 @@
+# Recursive wildcard function taken from https://stackoverflow.com/a/18258352
+
+rwildcard=$(foreach d,$(wildcard $(1:=/*)),$(call rwildcard,$d,$2) $(filter $(subst *,%,$2),$d))
+
 CC = gcc
 
 CFLAGS = -Wall -g -Iinclude
 
 TARGET = bshell
 
-SRC = src/main.c \
-      src/builtin/builtin.c \
-      src/builtin/cd.c \
-      src/builtin/help.c \
-      src/builtin/exit.c \
-      src/builtin/reconfigure.c
+SRC = $(call rwildcard,src,*.c)
 
 OBJ = $(SRC:.c=.o)
 

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,24 @@
 CC = gcc
-CFLAGS = -Wall -g
+
+CFLAGS = -Wall -g -Iinclude
+
 TARGET = bshell
+
+SRC = src/main.c \
+      src/builtin/builtin.c \
+      src/builtin/cd.c \
+      src/builtin/help.c \
+      src/builtin/exit.c \
+      src/builtin/reconfigure.c
+
+OBJ = $(SRC:.c=.o)
 
 all: 	$(TARGET)
 
-$(TARGET): main.c
-	$(CC) $(CFLAGS) -o $(TARGET) main.c
+$(TARGET): $(OBJ)
+	$(CC) $(OBJ) -o $(TARGET)
 
 clean:
 	$(RM) $(TARGET)
+fclean: clean
+	$(RM) $(OBJ)

--- a/include/bshell.h
+++ b/include/bshell.h
@@ -1,0 +1,45 @@
+#ifndef __BSHELL_H__
+#define __BSHELL_H__
+
+/*********************************************************/
+/* Includes */
+/*********************************************************/
+
+#include <sys/wait.h>
+// waitpid() and associated macros
+#include <unistd.h>
+// chdir, fork, exec, pid_t
+#include <stdlib.h>
+// malloc, realloc, free, exit, execvp, EXIT_SUCCESS, EXIT_FAILURE
+#include <stdio.h>
+// fprintf, printf, stderr, getchar, perror
+#include <string.h>
+// strcmp, strtok
+
+/*********************************************************/
+/* Forward Declarations */
+/*********************************************************/
+
+/* Core functions */
+char *bshell_read_line();
+char **bshell_split_line(char *line);
+void bshell_loop();
+int bshell_execute(char **args);
+void bshell_initialize();
+
+/*********************************************************/
+/* Constant Data */
+/*********************************************************/
+
+#define BSHELL_RL_BUFSIZE 1024
+
+#define BSHELL_TOK_BUFSIZE 64
+#define BSHELL_TOK_DELIM " \t\r\n\a"
+
+#define BSHELL_SETTINGS_FILE ".bshrc"
+#define BSHELL_SETTINGS_DELIM1 " "
+#define BSHELL_SETTINGS_DELIM2 "="
+
+extern char bshell_prompt_str[50];
+
+#endif /*__BSHELL_H__ */

--- a/include/bshell_builtin.h
+++ b/include/bshell_builtin.h
@@ -1,0 +1,21 @@
+#ifndef __BSHELL_BUILTIN_H__
+#define __BSHELL_BUILTIN_H__
+
+/*********************************************************/
+/* Forward Declarations */
+/*********************************************************/
+
+/* Built-in shell commands */
+int bshell_num_builtins();
+int bshell_cd(char **args);
+int bshell_help(char **args);
+int bshell_exit(char **args);
+int bshell_reconfigure();
+
+/* Definition of the list of built-in commands */
+extern const char *builtin_str[];
+
+/* Definition of the corresponding function pointer array */
+extern int (*const builtin_func[])(char **);
+
+#endif /* __BSHELL_BUILTIN_H__ */

--- a/src/builtin/builtin.c
+++ b/src/builtin/builtin.c
@@ -1,0 +1,15 @@
+#include "bshell_builtin.h"
+
+/* Definition of the extern variables */
+
+const char *builtin_str[] = {"cd", "help", "exit", "reconfigure"};
+
+int (*const builtin_func[])(char **) = {&bshell_cd, &bshell_help, &bshell_exit,&bshell_reconfigure};
+
+/*********************************************************/
+/* Utility Functions */
+/*********************************************************/
+
+int bshell_num_builtins() {
+  return sizeof(builtin_str) / sizeof(char *);
+}

--- a/src/builtin/cd.c
+++ b/src/builtin/cd.c
@@ -1,0 +1,13 @@
+#include "bshell.h"
+
+int bshell_cd(char **args) {
+  if (args[1] == NULL) {
+    fprintf(stderr, "bshell : expected argument to \"cd\"\n");
+  } else {
+    if (chdir(args[1]) != 0) {
+      perror("bshell - cd");
+    }
+  }
+
+  return 1;
+}

--- a/src/builtin/exit.c
+++ b/src/builtin/exit.c
@@ -1,0 +1,3 @@
+#include "bshell.h"
+
+int bshell_exit(char **args) { return 0; }

--- a/src/builtin/help.c
+++ b/src/builtin/help.c
@@ -1,0 +1,17 @@
+#include "bshell.h"
+#include "bshell_builtin.h"
+
+int bshell_help(char **args) {
+  int i;
+  printf("BSHELL\n");
+  printf("Based on Stephen Brennan's LSH\n");
+  printf("Type program names and arguments, and hit enter.\n");
+  printf("The following are built-in:\n");
+
+  for (i = 0; i < bshell_num_builtins(); i++) {
+    printf("  %s\n", builtin_str[i]);
+  }
+
+  printf("Use the man command for information on other programs.\n");
+  return 1;
+}

--- a/src/builtin/reconfigure.c
+++ b/src/builtin/reconfigure.c
@@ -1,0 +1,6 @@
+#include "bshell.h"
+
+int bshell_reconfigure() {
+  bshell_initialize();
+  return 1;
+}

--- a/src/main.c
+++ b/src/main.c
@@ -1,100 +1,7 @@
-/*********************************************************/
-/* Includes */
-/*********************************************************/
-
-#include <sys/wait.h>
-// waitpid() and associated macros
-#include <unistd.h>
-// chdir, fork, exec, pid_t
-#include <stdlib.h>
-// malloc, realloc, free, exit, execvp, EXIT_SUCCESS, EXIT_FAILURE
-#include <stdio.h>
-// fprintf, printf, stderr, getchar, perror
-#include <string.h>
-// strcmp, strtok
-
-/*********************************************************/
-/* Forward Declarations */
-/*********************************************************/
-
-/* Built-in shell commands */
-int bshell_cd(char **args);
-int bshell_help(char **args);
-int bshell_exit(char **args);
-int bshell_reconfigure();
-
-/* Core functions */
-char *bshell_read_line();
-char **bshell_split_line(char *line);
-void bshell_loop();
-int bshell_execute(char **args);
-void bshell_initialize();
-
-/*********************************************************/
-/* Constant Data */
-/*********************************************************/
-
-#define BSHELL_RL_BUFSIZE 1024
-
-#define BSHELL_TOK_BUFSIZE 64
-#define BSHELL_TOK_DELIM " \t\r\n\a"
-
-#define BSHELL_SETTINGS_FILE ".bshrc"
-#define BSHELL_SETTINGS_DELIM1 " "
-#define BSHELL_SETTINGS_DELIM2 "="
+#include "bshell.h"
+#include "bshell_builtin.h"
 
 char bshell_prompt_str[50] = "> ";
-
-/* List of built-in commands */
-char *builtin_str[] = {"cd", "help", "exit", "reconfigure"};
-
-/* Their corresponding functions */
-int (*builtin_func[])(char **) = {&bshell_cd, &bshell_help, &bshell_exit,
-                                  &bshell_reconfigure};
-
-/*********************************************************/
-/* Utility Functions */
-/*********************************************************/
-
-int bshell_num_builtins() { return sizeof(builtin_str) / sizeof(char *); }
-
-/*********************************************************/
-/* Built-in function implementations */
-/*********************************************************/
-
-int bshell_cd(char **args) {
-  if (args[1] == NULL) {
-    fprintf(stderr, "bshell : expected argument to \"cd\"\n");
-  } else {
-    if (chdir(args[1]) != 0) {
-      perror("bshell - cd");
-    }
-  }
-
-  return 1;
-}
-
-int bshell_help(char **args) {
-  int i;
-  printf("BSHELL\n");
-  printf("Based on Stephen Brennan's LSH\n");
-  printf("Type program names and arguments, and hit enter.\n");
-  printf("The following are built-in:\n");
-
-  for (i = 0; i < bshell_num_builtins(); i++) {
-    printf("  %s\n", builtin_str[i]);
-  }
-
-  printf("Use the man command for information on other programs.\n");
-  return 1;
-}
-
-int bshell_exit(char **args) { return 0; }
-
-int bshell_reconfigure() {
-  bshell_initialize();
-  return 1;
-}
 
 /*********************************************************/
 /* Core functions */
@@ -118,7 +25,7 @@ void bshell_loop() {
   int status;
 
   do {
-    printf(bshell_prompt_str);
+    printf("%s", bshell_prompt_str);
     line = bshell_read_line();
     args = bshell_split_line(line);
     status = bshell_execute(args);


### PR DESCRIPTION
A proposition to fix #13
(Also fix a Warning about passing a string directly to `printf` without "%s")